### PR TITLE
Add engineering guide, contributing guide, and ADRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Smart Plant
+
+Thank you for helping build Smart Plant! This guide documents the minimum steps for setting up your environment, running quality checks, and preparing pull requests.
+
+## 1. Environment Setup
+
+1. Install [Node.js](https://nodejs.org/) **v18 LTS** or later (includes npm).
+2. Clone the repository and install dependencies:
+   ```bash
+   git clone <repo-url>
+   cd plantcare
+   npm install
+   ```
+3. Copy any required environment examples and fill in secrets for local use:
+   ```bash
+   cp .env.example .env.local
+   # populate PlantNet and OpenAI keys as needed
+   ```
+
+## 2. Available Scripts
+
+* `npm run dev` – Start the Vite dev server.
+* `npm run build` – Generate a production bundle.
+* `npm run preview` – Serve the production build locally.
+* `npm run test` – Run unit and integration tests via Vitest.
+* `npm run lint` – Run ESLint checks.
+* `npm run format` – Format code with Prettier (if defined in package.json).
+
+## 3. Testing & Linting Requirements
+
+Before opening a pull request, you must run:
+
+```bash
+npm run lint
+npm run test
+```
+
+Ensure both commands exit with status 0. Add or update tests when modifying behavior, especially around schema validation, caching, or service integrations.
+
+## 4. Commit & Branch Strategy
+
+* Work on feature branches named `feature/<short-description>` (or `fix/`, `docs/` as appropriate).
+* Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages (e.g., `feat: add cache TTL enforcement`).
+* Rebase on `main` before requesting a review to keep history linear.
+
+## 5. Pull Request Process
+
+1. Ensure your branch is up to date with `main` and all required checks pass locally.
+2. Open a PR with a concise title and summary describing **what** changed and **why**.
+3. Link related issues or ADRs when applicable.
+4. Request review from at least one project maintainer.
+5. Address review feedback promptly; update tests and documentation as needed.
+6. CI must report green (lint, tests, type checks) before merge. Maintainers will squash-and-merge once approved.
+
+## 6. Code Style & Documentation
+
+* Follow `docs/CODING_GUIDELINES.md` and `docs/STYLE_GUIDE.md` for style conventions.
+* Update or add ADRs when architectural choices change.
+* Document new public APIs in `docs/API_CONTRACTS.md`.
+
+By contributing, you agree to uphold the project's guiding principles and quality standards described in the Engineering Guide.

--- a/ENGINEERING_GUIDE.md
+++ b/ENGINEERING_GUIDE.md
@@ -1,0 +1,83 @@
+# 🪴 Smart Plant – Engineering Guide
+
+## 1. Purpose
+
+This document defines the **software stack, design methodology, and engineering principles** for the Smart Plant project.
+It ensures that all contributors follow the same approach, making the system consistent, portable, and maintainable.
+
+---
+
+## 2. Guiding Principles
+
+* **All on device**: No maintained backend servers. Photos go only to PlantNet; ChatGPT receives *text only*.
+* **Lean + clear**: Minimal features, robust error handling, simple UX.
+* **Cache first**: Species policies are cached locally with TTL (default 180 days).
+* **Schema enforced**: ChatGPT must return *strict JSON* matching our schema; invalid responses never persist.
+* **Portable by design**: Service boundaries defined so web and mobile apps can share the same logic.
+
+---
+
+## 3. Software Stack
+
+### Frontend
+
+* **Framework:** React 18 (TypeScript)
+* **Bundler/Dev Server:** Vite
+* **Testing:** Vitest + React Testing Library
+* **Styling:** CSS modules + tokens (spacing, colors, typography)
+
+### Data & Storage
+
+* **Local database:** SQLite (via localForage or platform equivalent)
+* **Cache TTL:** 180 days default; force refresh supported
+* **Schema validation:** Custom validators (policySchema)
+
+### External Integrations
+
+* **Plant Identification:** PlantNet API (via proxy in dev; direct in prod)
+* **Policy Generation:** OpenAI ChatGPT (text only; strict JSON enforced)
+
+### Tooling
+
+* **Package manager:** npm
+* **Scripts:** `dev`, `build`, `preview`, `test` defined in `package.json`
+* **Linting/formatting:** ESLint + Prettier
+
+---
+
+## 4. Design Methodology
+
+* **MVP-first:** Build smallest useful flow (Add Plant → ID → Policy → Save → Display).
+* **Service-oriented:** Encapsulate integrations behind providers:
+
+  * `id/plantNet.ts` → identification provider (real + mock)
+  * `policy/chatgpt.ts` → policy provider (real + mock)
+  * `storage/kv.ts` → abstracted storage (web vs RN)
+* **Strict typing:** Domain models (Plant, SpeciesProfile, MoisturePolicy) enforced via TypeScript + runtime validators.
+* **Error taxonomy:** All errors mapped to `NETWORK_ERROR | INVALID_IMAGE | API_ERROR | SCHEMA_ERROR`.
+
+---
+
+## 5. Testing & Quality
+
+* **Unit tests:** schema validation, cache TTL logic, stepper navigation.
+* **Integration tests:** Add Plant flow (happy path, low-confidence path, error fallback).
+* **UI tests:** PlantCard rendering, Settings toggles.
+* **Accessibility:** Components must support keyboard navigation and have labels/alt text.
+
+---
+
+## 6. Contribution Rules
+
+* **Branching:** `main` (stable), feature branches (`feature/<name>`).
+* **Commits:** Conventional commits style (`feat:`, `fix:`, `docs:`).
+* **Reviews:** At least one reviewer approval required.
+* **CI checks:** Lint, unit tests, and type checks must pass before merge.
+
+---
+
+## 7. Future-Proofing
+
+* **Mobile prep:** React Native port reuses services/logic; only storage and UI differ.
+* **Premium hardware integration:** Device SDKs wrapped in services with the same abstraction model.
+* **Accounts (optional later):** Models include optional `ownerId` field for potential sync.

--- a/docs/adr/001-frontend-stack.md
+++ b/docs/adr/001-frontend-stack.md
@@ -1,0 +1,22 @@
+# ADR 001: Frontend Stack Selection
+
+## Status
+Accepted
+
+## Context
+The Smart Plant experience must run on modern browsers with fast iteration loops, rich developer tooling, and strong TypeScript support. We rely on component-driven UI and need predictable concurrent rendering for latency-sensitive features such as live camera previews and optimistic cache updates. Startup performance is critical because the app is distributed as a lightweight web bundle and potentially wrapped for mobile.
+
+## Decision
+We adopt **React 18** paired with **Vite**.
+
+* React 18 delivers concurrent rendering, Suspense for data fetching, and automatic batching, which aligns with our need to show cached plant policies immediately while deferring network calls.
+* React's ecosystem (hooks, React Testing Library, community libraries) matches our testing strategy and service abstractions already defined in the project.
+* Vite provides a lightning-fast dev server with native ES modules, enabling sub-second hot module replacement for rapid experimentation on UI flows.
+* Vite's opinionated yet flexible build pipeline outputs optimized, tree-shaken bundles and handles TypeScript transpilation without heavy configuration, keeping the stack lean and portable.
+* The React 18 + Vite pairing is widely supported by our chosen testing tools (Vitest) and linting setup (ESLint + Prettier), minimizing integration friction.
+
+## Consequences
+* Developers can iterate quickly with HMR and TypeScript type checking that matches our schema-first approach.
+* Production builds stay small, improving perceived performance for on-device usage.
+* The community support and documentation for React and Vite reduce onboarding time for new contributors.
+* We inherit the need to stay current with React 18's concurrent patterns and Vite plugin updates, but these are acceptable trade-offs for the productivity gains.

--- a/docs/adr/002-cache-first-design.md
+++ b/docs/adr/002-cache-first-design.md
@@ -1,0 +1,22 @@
+# ADR 002: Cache-First Species Policy Design
+
+## Status
+Accepted
+
+## Context
+Plant identification and policy generation depend on external services (PlantNet and ChatGPT). Network availability is intermittent, and repeated requests increase latency and API costs. Users revisit plant guidance infrequently, so most information remains valid for months. We also commit to an on-device experience without managed servers, making resilient local storage essential.
+
+## Decision
+Implement a cache-first strategy with enforced time-to-live (TTL) values for species policies.
+
+* Species policies and identification metadata are stored locally using SQLite via platform-specific storage adapters.
+* Entries default to a **180-day TTL**, matching horticulture guidance refresh cycles. Policies can be manually refreshed when users suspect outdated data.
+* Cache lookups drive the UI: the app displays cached policies immediately, then decides whether to revalidate based on TTL expiry or explicit refresh actions.
+* TTL enforcement occurs at read time (reject stale entries) and via periodic cleanup tasks to keep storage lean.
+* All cache operations pass through typed storage services (`storage/kv.ts`), allowing web and mobile to share logic while swapping implementations.
+
+## Consequences
+* Users gain instant access to existing plant care advice even when offline.
+* Network calls are minimized, protecting rate limits and reducing third-party dependency risk.
+* The TTL boundary creates predictable behavior for stale data and simplifies testing of cache logic.
+* We must maintain validators to prevent corrupt or schema-invalid cache entries from persisting, but this aligns with our schema enforcement principle.


### PR DESCRIPTION
## Summary
- add ADR documenting the React 18 + Vite frontend stack decision
- add ADR covering cache-first species policy design with TTL enforcement
- publish engineering guide and contributing guide for contributors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dacdeeeb74832bbd22d6d22d93e5c5