### PR TITLE
Add tests for plant actions menu and sorting

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -146,11 +146,11 @@
 
 * Data source: use the local store (SQLite layer) read.
 * PlantCard component shows: photo (or placeholder), canonical/common name, one-line moisture policy summary (e.g., “Mostly dry 2–3 days; water <12%”), and last updated.
-* Actions menu (kebab):
+* [x] Actions menu (kebab):
   * View details (future)
-  * Rename/nickname (optional; simple inline edit)
-  * Delete (with confirm modal)
-* Basic sort: by `createdAt` desc (default).
+  * [x] Rename/nickname (optional; simple inline edit)
+  * [x] Delete (with confirm modal)
+* [x] Basic sort: by `createdAt` desc (default).
 
 **Definition of Done**
 

--- a/app/src/screens/HomeScreen.test.tsx
+++ b/app/src/screens/HomeScreen.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import HomeScreen from "./HomeScreen";
+import type { Plant } from "@core/models/plant";
+import type { SpeciesProfile } from "@core/models/speciesProfile";
+import type { MoisturePolicy } from "@core/models/moisturePolicy";
+
+const basePolicy: MoisturePolicy = {
+  waterIntervalDays: 2,
+  soilMoistureThreshold: 10,
+  humidityPreference: "medium",
+  lightRequirement: "bright-indirect",
+  notes: [],
+};
+
+const buildPlant = (overrides: Partial<Plant>): Plant => ({
+  id: "plant-" + overrides.id,
+  speciesKey: "species-" + (overrides.id ?? "1"),
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+const buildProfile = (speciesKey: string, names: { canonical: string; common?: string }): SpeciesProfile => ({
+  speciesKey,
+  canonicalName: names.canonical,
+  commonName: names.common,
+  type: "tropical",
+  moisturePolicy: basePolicy,
+  source: "seed",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+});
+
+describe("HomeScreen", () => {
+  it("sorts plants by createdAt descending", () => {
+    const plants: Plant[] = [
+      buildPlant({ id: "a", nickname: "Alpha", createdAt: "2024-03-01T10:00:00.000Z" }),
+      buildPlant({ id: "b", nickname: "Bravo", createdAt: "2024-05-01T10:00:00.000Z" }),
+      buildPlant({ id: "c", nickname: "Charlie", createdAt: "2024-04-01T10:00:00.000Z" }),
+    ];
+
+    const speciesCache: Record<string, SpeciesProfile> = Object.fromEntries(
+      plants.map((plant) => [
+        plant.speciesKey,
+        buildProfile(plant.speciesKey, { canonical: plant.nickname ?? plant.speciesKey }),
+      ]),
+    );
+
+    render(
+      <HomeScreen
+        plants={plants}
+        speciesCache={speciesCache}
+        onAddPlant={() => {}}
+        status="ready"
+        onRenamePlant={() => {}}
+        onDeletePlant={() => {}}
+      />,
+    );
+
+    const headings = screen.getAllByRole("heading", { level: 4 });
+    const order = headings.map((heading) => heading.textContent);
+
+    expect(order).toEqual(["Bravo", "Charlie", "Alpha"]);
+  });
+});

--- a/app/src/screens/home/PlantCard.test.tsx
+++ b/app/src/screens/home/PlantCard.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import PlantCard from "./PlantCard";
+import type { Plant } from "@core/models/plant";
+import type { SpeciesProfile } from "@core/models/speciesProfile";
+import type { MoisturePolicy } from "@core/models/moisturePolicy";
+
+const mockPolicy: MoisturePolicy = {
+  waterIntervalDays: 3,
+  soilMoistureThreshold: 12,
+  humidityPreference: "medium",
+  lightRequirement: "bright-indirect",
+  notes: ["Mist weekly"],
+};
+
+const basePlant: Plant = {
+  id: "plant-1",
+  speciesKey: "ficus-lyrata",
+  nickname: "Figgy",
+  photoUri: "https://example.com/plant.jpg",
+  createdAt: "2024-05-01T12:00:00.000Z",
+  updatedAt: "2024-05-02T12:00:00.000Z",
+};
+
+const baseProfile: SpeciesProfile = {
+  speciesKey: "ficus-lyrata",
+  canonicalName: "Ficus lyrata",
+  commonName: "Fiddle Leaf Fig",
+  type: "tropical",
+  moisturePolicy: mockPolicy,
+  source: "seed",
+  updatedAt: "2024-04-01T12:00:00.000Z",
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PlantCard", () => {
+  it("calls onRename with trimmed nickname", async () => {
+    const handleRename = vi.fn().mockResolvedValue(undefined);
+
+    render(<PlantCard plant={basePlant} profile={baseProfile} onRename={handleRename} />, { legacyRoot: true });
+
+    const [card] = screen.getAllByRole("article", { name: basePlant.nickname ?? "" });
+    const utils = within(card);
+    const menuButton = utils.getByRole("button", { name: /plant actions/i });
+    fireEvent.click(menuButton);
+    fireEvent.click(await utils.findByRole("menuitem", { name: /rename/i }));
+
+    const input = await utils.findByLabelText(/nickname/i);
+    fireEvent.change(input, { target: { value: "  New Fig  " } });
+
+    const form = input.closest("form");
+    expect(form).not.toBeNull();
+    if (!form) return;
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(handleRename).toHaveBeenCalledWith(basePlant.id, "New Fig");
+    });
+  });
+
+  it("confirms deletion before calling onDelete", async () => {
+    const handleDelete = vi.fn().mockResolvedValue(undefined);
+
+    render(<PlantCard plant={basePlant} profile={baseProfile} onDelete={handleDelete} />, { legacyRoot: true });
+
+    const [card] = screen.getAllByRole("article", { name: basePlant.nickname ?? "" });
+    const utils = within(card);
+    const menuButton = utils.getByRole("button", { name: /plant actions/i });
+    fireEvent.click(menuButton);
+    const deleteMenuItem = await utils.findByRole("menuitem", { name: /delete/i });
+    fireEvent.click(deleteMenuItem);
+
+    const dialog = await screen.findByRole("alertdialog");
+    const deleteButton = within(dialog).getByRole("button", { name: /delete plant/i });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(handleDelete).toHaveBeenCalledWith(basePlant.id);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add PlantCard tests that exercise rename and delete flows through the actions menu
- add a HomeScreen test that verifies plants render in createdAt descending order

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dafb22ed24832b9dee7a62a2c795a9