### PR TITLE
Implement virtualized home list and accessibility improvements

### DIFF
--- a/app/src/screens/home/PlantCard.test.tsx
+++ b/app/src/screens/home/PlantCard.test.tsx
@@ -46,7 +46,7 @@ describe("PlantCard", () => {
 
     render(<PlantCard plant={basePlant} profile={baseProfile} onRename={handleRename} />, { legacyRoot: true });
 
-    const [card] = screen.getAllByRole("article", { name: basePlant.nickname ?? "" });
+    const [card] = screen.getAllByRole("listitem", { name: basePlant.nickname ?? "" });
     const utils = within(card);
     const menuButton = utils.getByRole("button", { name: /plant actions/i });
     fireEvent.click(menuButton);
@@ -70,7 +70,7 @@ describe("PlantCard", () => {
 
     render(<PlantCard plant={basePlant} profile={baseProfile} onDelete={handleDelete} />, { legacyRoot: true });
 
-    const [card] = screen.getAllByRole("article", { name: basePlant.nickname ?? "" });
+    const [card] = screen.getAllByRole("listitem", { name: basePlant.nickname ?? "" });
     const utils = within(card);
     const menuButton = utils.getByRole("button", { name: /plant actions/i });
     fireEvent.click(menuButton);

--- a/app/src/screens/home/PlantCard.tsx
+++ b/app/src/screens/home/PlantCard.tsx
@@ -1,4 +1,13 @@
-import { FormEvent, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  FormEvent,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { Plant } from "@core/models/plant";
 import type { SpeciesProfile } from "@core/models/speciesProfile";
 import { buildPlantPolicySummary, formatLastUpdated, selectPlantPolicy } from "./policySummary";
@@ -17,7 +26,10 @@ const resolveDisplayNames = (plant: Plant, profile?: SpeciesProfile) => {
   return { primary, secondary, tertiary };
 };
 
-const PlantCard = ({ plant, profile, onRename, onDelete }: PlantCardProps) => {
+const PlantCard = forwardRef<HTMLElement, PlantCardProps>(function PlantCard(
+  { plant, profile, onRename, onDelete }: PlantCardProps,
+  forwardedRef,
+) {
   const menuButtonId = useId();
   const confirmTitleId = useId();
   const confirmDescId = useId();
@@ -131,13 +143,19 @@ const PlantCard = ({ plant, profile, onRename, onDelete }: PlantCardProps) => {
     [plant.updatedAt, profile?.updatedAt],
   );
 
-  const photoAlt = `${primary} photo`;
+  const photoAlt = plant.photoUri ? `${primary} plant photo` : `${primary} placeholder image`;
 
   return (
-    <article className="card plant-card" aria-label={primary}>
+    <article
+      className="card plant-card"
+      aria-label={primary}
+      tabIndex={0}
+      role="listitem"
+      ref={forwardedRef}
+    >
       <div className="plant-card__media">
         {plant.photoUri ? (
-          <img src={plant.photoUri} alt={photoAlt} className="plant-card__image" />
+          <img src={plant.photoUri} alt={photoAlt} className="plant-card__image" loading="lazy" />
         ) : (
           <div className="plant-card__placeholder" aria-hidden="true">
             <svg viewBox="0 0 80 80" role="presentation" focusable="false">
@@ -272,6 +290,6 @@ const PlantCard = ({ plant, profile, onRename, onDelete }: PlantCardProps) => {
       )}
     </article>
   );
-};
+});
 
 export default PlantCard;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -179,11 +179,30 @@ p {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
+.plant-list__virtual-outer {
+  position: relative;
+  width: 100%;
+}
+
+.plant-list__virtual-inner {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  display: grid;
+  gap: inherit;
+  will-change: transform;
+}
+
 .plant-card {
   grid-template-columns: 128px 1fr;
   align-items: stretch;
   position: relative;
   overflow: hidden;
+}
+
+.plant-card:focus-visible {
+  outline: 2px solid var(--color-secondary-mid);
+  outline-offset: 4px;
 }
 
 .plant-card__media {


### PR DESCRIPTION
## Summary
- virtualize the saved plants list when more than 50 entries to improve scrolling performance
- make plant cards keyboard focusable list items with improved image alt text and lazy loading for photos
- add visible focus styling and update tests to cover the new semantics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db053d08c8832bbb5d60a668b762ca